### PR TITLE
Настройки рамки окна: отвязать расположение кнопок от платформы

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ yarn run release
 yarn run release:mac
 
 # Сборка под Windows
-yarn run release:win
+yarn run release:windows
 
 # Сборка под Linux
-yarn run release:lin
+yarn run release:linux
 ```

--- a/src/renderer/components/app/settings/sections/system/SettingsSystem.vue
+++ b/src/renderer/components/app/settings/sections/system/SettingsSystem.vue
@@ -19,6 +19,7 @@
     import {SET_HAS_NOTIFICATIONS_ACTION} from '@store/app/settings/system/settingsSystemStore'
     import {SET_HAS_ADS_ACTION, SET_HAS_MAXIMUM_ADS_ACTION} from '@store/app/settings/system/settingsSystemStore'
     import {SET_HAS_AUTO_UPDATES_ACTION, SET_AUTO_UPDATES_TIMEOUT_ACTION} from '@store/app/settings/system/settingsSystemStore'
+    import {SET_WIN_FRAME_STYLE_ACTION} from '@store/app/settings/system/settingsSystemStore'
 
 
     const props = {
@@ -38,6 +39,7 @@
                 _hasAutoUpdates: s => s.hasAutoUpdates === true,
                 _hasNotifications: s => s.hasNotifications === true,
                 _autoUpdatesTimeout: s => s.autoUpdatesTimeout,
+                _rightFrameButtons: s => s.winFrameStyle === true
             }),
 
 
@@ -63,6 +65,16 @@
                             value: this._hasNotifications,
                             description: ['Если при загрузке последних релизов приложение обнаружит обновленный релиз, то оно покажет системное уведомление о новом эпизоде'],
                             inputHandler: $event => this[SET_HAS_NOTIFICATIONS_ACTION]($event)
+                        },
+                        classes: ['mb-2']
+                    },
+                    {
+                        is: Switch,
+                        props: {
+                            title: 'Windows-style рамка окна',
+                            value: this._rightFrameButtons,
+                            description: ['Расположение кнопок на рамке окна справа'],
+                            inputHandler: $event => this[SET_WIN_FRAME_STYLE_ACTION]($event)
                         },
                         classes: ['mb-2']
                     },
@@ -149,6 +161,7 @@
             ...mapActions('app/settings/system', [SET_HAS_NOTIFICATIONS_ACTION]),
             ...mapActions('app/settings/system', [SET_HAS_ADS_ACTION, SET_HAS_MAXIMUM_ADS_ACTION]),
             ...mapActions('app/settings/system', [SET_HAS_AUTO_UPDATES_ACTION, SET_AUTO_UPDATES_TIMEOUT_ACTION]),
+            ...mapActions('app/settings/system', [SET_WIN_FRAME_STYLE_ACTION]),
         },
 
 

--- a/src/renderer/components/app/systembar/AppSystemBar.vue
+++ b/src/renderer/components/app/systembar/AppSystemBar.vue
@@ -7,7 +7,7 @@
     @dblclick="() => maximizeApp()">
 
     <template v-if="!this.isMac">
-      <v-spacer v-if="this.isWindows"/>
+      <v-spacer v-if="this._winFrameStyle"/>
       <template v-for="(control, k) in controls">
         <v-btn icon small class="system-bar__button" :key="k" @click="control.action">
           <v-icon small color="grey">{{control.icon}}</v-icon>
@@ -21,11 +21,12 @@
 <script>
 
   import {AppPlatformMixin} from '@mixins/app'
+import { mapState } from 'vuex';
 
   export default {
     mixins: [AppPlatformMixin],
     computed: {
-
+			...mapState('app/settings/system', { _winFrameStyle: s => s.winFrameStyle === true }),
 
       /**
        * Get controls
@@ -36,18 +37,18 @@
         return [
           {
             icon: 'mdi-minus',
-            sort: this.isWindows ? 0 : 1,
+            sort: this._winFrameStyle ? 0 : 1,
             action: () => this.minimizeApp(),
           },
           {
             icon: 'mdi-window-maximize',
             action: () => this.maximizeApp(),
-            sort: this.isWindows ? 1 : 2
+            sort: this._winFrameStyle ? 1 : 2
           },
           {
             icon: 'mdi-close',
             action: () => this.closeApp(),
-            sort: this.isWindows ? 2 : 0
+            sort: this._winFrameStyle ? 2 : 0
           },
         ].sort((a, b) => a.sort - b.sort)
       }
@@ -71,6 +72,7 @@
        * @return void
        */
       minimizeApp() {
+				alert(this._winFrameStyle);
         require('@electron/remote').getCurrentWindow().minimize();
       },
 

--- a/src/renderer/store/app/settings/system/settingsSystemStore.js
+++ b/src/renderer/store/app/settings/system/settingsSystemStore.js
@@ -6,6 +6,7 @@ const SET_CONNECTION_HOST_MUTATION = 'SET_CONNECTION_HOST_MUTATION';
 const SET_HAS_AUTO_UPDATES_MUTATION = 'SET_HAS_AUTO_UPDATES_MUTATION';
 const SET_HAS_NOTIFICATIONS_MUTATION = 'SET_HAS_NOTIFICATIONS_MUTATION';
 const SET_AUTO_UPDATES_TIMEOUT_MUTATION = 'SET_AUTO_UPDATES_TIMEOUT_MUTATION';
+const SET_WIN_FRAME_STYLE_MUTATION = 'SET_WIN_FRAME_STYLE_MUTATION';
 
 // Actions
 export const SET_HAS_ADS_ACTION = 'SET_HAS_ADS_ACTION';
@@ -15,11 +16,13 @@ export const SET_CONNECTION_HOST_ACTION = 'SET_CONNECTION_HOST_ACTION';
 export const SET_HAS_AUTO_UPDATES_ACTION = 'SET_HAS_AUTO_UPDATES_ACTION';
 export const SET_HAS_NOTIFICATIONS_ACTION = 'SET_HAS_NOTIFICATIONS_ACTION';
 export const SET_AUTO_UPDATES_TIMEOUT_ACTION = 'SET_AUTO_UPDATES_TIMEOUT_ACTION';
+export const SET_WIN_FRAME_STYLE_ACTION = 'SET_WIN_FRAME_STYLE_ACTION';
 
 export default {
     namespaced: true,
     state: {
         hasAds: true,
+				winFrameStyle: process.platform === 'win32',
         showDevtools: false,
         hasMaximumAds: false,
         hasAutoUpdates: true,
@@ -34,6 +37,7 @@ export default {
         [SET_HAS_MAXIMUM_ADS_MUTATION]: (s, hasMaximumAds) => s.hasMaximumAds = hasMaximumAds === true,
         [SET_CONNECTION_HOST_MUTATION]: (s, connectionHost) => s.connectionHost = connectionHost,
         [SET_HAS_AUTO_UPDATES_MUTATION]: (s, hasAutoUpdates) => s.hasAutoUpdates = hasAutoUpdates === true,
+        [SET_WIN_FRAME_STYLE_MUTATION]: (s, winFrameStyle) => s.winFrameStyle = winFrameStyle === true,
         [SET_HAS_NOTIFICATIONS_MUTATION]: (s, hasNotifications) => s.hasNotifications = hasNotifications === true,
         [SET_AUTO_UPDATES_TIMEOUT_MUTATION]: (s, autoUpdatesTimeout) => s.autoUpdatesTimeout = autoUpdatesTimeout,
     },
@@ -44,6 +48,7 @@ export default {
         [SET_HAS_MAXIMUM_ADS_ACTION]: ({commit}, isMaximumAds) => commit(SET_HAS_MAXIMUM_ADS_MUTATION, isMaximumAds),
         [SET_CONNECTION_HOST_ACTION]: ({commit}, connectionHost) => commit(SET_CONNECTION_HOST_MUTATION, connectionHost),
         [SET_HAS_AUTO_UPDATES_ACTION]: ({commit}, updatesAreEnabled) => commit(SET_HAS_AUTO_UPDATES_MUTATION, updatesAreEnabled),
+        [SET_WIN_FRAME_STYLE_ACTION]: ({commit}, winFrameStyle) => commit(SET_WIN_FRAME_STYLE_MUTATION, winFrameStyle),
         [SET_HAS_NOTIFICATIONS_ACTION]: ({commit}, hasNotifications) => commit(SET_HAS_NOTIFICATIONS_MUTATION, hasNotifications),
         [SET_AUTO_UPDATES_TIMEOUT_ACTION]: ({commit}, updatesTimeoutMinutes) => commit(SET_AUTO_UPDATES_TIMEOUT_MUTATION, updatesTimeoutMinutes),
     }


### PR DESCRIPTION
Добавляется свич в настройки. +Fix README
Хорошо бы еще иметь возможность системную рамку использовать, но у меня, видимо, тогда до этого руки не дошли)